### PR TITLE
fix: patch tabindex rule

### DIFF
--- a/lib/rules/tabindex-no-positive.js
+++ b/lib/rules/tabindex-no-positive.js
@@ -23,14 +23,9 @@ module.exports = {
   create (context) {
     return VueUtils.defineTemplateBodyVisitor(context, {
       "VAttribute" (node) {
-        let tabindex;
-        if (node.directive) {
-          tabindex = node.key.argument.name === 'tabindex';
-        } else {
-          tabindex = node.key.name === 'tabindex';
-        }
-
-        if (!tabindex) {
+        const isTabindex = (!node.directive && node.key.name === 'tabindex')
+          || (node.key.name.name === 'bind' && node.key.argument.name === 'tabindex')
+        if (!isTabindex) {
           return;
         }
 

--- a/tests/lib/rules/tabindex-no-positive.js
+++ b/tests/lib/rules/tabindex-no-positive.js
@@ -25,6 +25,10 @@ tester.run('tabindex-no-positive', rule, {
     },
     {
       filename: 'test.vue',
+      code: '<template><span v-if="true" tabindex="0"></span></template>',
+    },
+    {
+      filename: 'test.vue',
       code: '<template><span tabindex="-1"></span></template>',
     },
     {


### PR DESCRIPTION
I fixed error in `tabindex-no-positive`.  #12 could not consider `v-if`.
Please review again 🙇 

↓error
```
 1) tabindex-no-positive valid <template><span v-if="true" tabindex="0"></span></template>:
    TypeError: Cannot read property 'name' of null
     at EventEmitter.VAttribute (lib/rules/tabindex-no-positive.js:28:40)
```

patch #12 
fixed #7